### PR TITLE
rename `AsDeclaredNameTest`

### DIFF
--- a/statik-api/src/test/kotlin/com/rickbusarow/statik/name/AsDeclaredNameTest.kt
+++ b/statik-api/src/test/kotlin/com/rickbusarow/statik/name/AsDeclaredNameTest.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.name.FqName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class AsDeclaredNameTestElement {
+internal class AsDeclaredNameTest {
 
   @Nested
   inner class `FqName` {


### PR DESCRIPTION
Not sure which refactor the -Element suffix came from.